### PR TITLE
Enum value should start with 0 by default (unless manually assigned) …

### DIFF
--- a/CsScala/WriteEnum.cs
+++ b/CsScala/WriteEnum.cs
@@ -64,7 +64,7 @@ namespace CsScala
         private static int DetermineEnumValue(EnumMemberDeclarationSyntax syntax, ref int lastEnumValue)
         {
             if (syntax.EqualsValue == null)
-                return ++lastEnumValue;
+                return lastEnumValue++;
 
 
             if (!int.TryParse(syntax.EqualsValue.Value.ToString(), out lastEnumValue))


### PR DESCRIPTION
Enum value should start with 0 by default (unless manually assigned) - this is to match C#’s default behaviour.

This will fix problems we see in the case below:
```
MyEnum
{
   First,
   Second
}

MyEnum unSetEnum;

Assert.IsTrue(MyEnum.First == unSetEnum); // pass in C# but not in scala
Assert.AreEqual(0, (int)unSetEnum); // pass in C# but not in scala

```

