### PR TITLE
This is a better fix to enum ordering issue

### DIFF
--- a/CsScala/WriteEnum.cs
+++ b/CsScala/WriteEnum.cs
@@ -18,7 +18,7 @@ namespace CsScala
             writer.Write("\r\n");
             writer.WriteOpenBrace();
 
-            int lastEnumValue = 0;
+            int lastEnumValue = -1;
 
             var values = allChildren.Select(o => new { Syntax = o, Value = DetermineEnumValue(o, ref lastEnumValue) }).ToList();
 
@@ -64,7 +64,7 @@ namespace CsScala
         private static int DetermineEnumValue(EnumMemberDeclarationSyntax syntax, ref int lastEnumValue)
         {
             if (syntax.EqualsValue == null)
-                return lastEnumValue++;
+                return ++lastEnumValue;
 
 
             if (!int.TryParse(syntax.EqualsValue.Value.ToString(), out lastEnumValue))


### PR DESCRIPTION
Original fix will not work in this case:
```
public enum MostlyNumbered
    {
        One = 1,
        Two = 2,
        Three = 3,
        Unnumbered,  // previous fix will generate as tag 3 in scala.
        SomethingElse = 50
    }
```